### PR TITLE
Fixed typographical error, changed adquire to acquire in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ a brief description or link to your interest for this code (one or two
 lines). There will be a section with links to research/papers/software
 that use BayesOpt.
 
-- Commercial applications may also adquire a **commercial license**. Please
+- Commercial applications may also acquire a **commercial license**. Please
 contact <rmcantin@unizar.es> for details.
 
 


### PR DESCRIPTION
@rmcantin, I've corrected a typographical error in the documentation of the [bayesopt](https://github.com/rmcantin/bayesopt) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.