### PR TITLE
Fixing "cannot convert std::stdistream to bool" (#18)

### DIFF
--- a/utils/fileparser.cpp
+++ b/utils/fileparser.cpp
@@ -85,7 +85,7 @@ namespace bayesopt
     /* Checks if a file exists */
     bool FileParser::fileExists(){
         std::ifstream ifile(filename.c_str());
-        bool result = ifile;
+        bool result = static_cast<bool>(ifile);
         ifile.close();
         return result;
     }


### PR DESCRIPTION
According to Porting Guide GCC 6 as mentioned in:
https://stackoverflow.com/questions/38659115/make-fails-with-error-cannot-convert-stdistream-aka-stdbasic-istreamchar